### PR TITLE
Fix broken link and instructions on testing doc changes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ Please:
 - Only edit the `/content` folder via the main Authelia [monorepo](https://github.com/authelia/authelia/tree/master/docs)
 - Edit everything else via the Authelia [website repo](https://github.com/authelia/website)
 
-See the [Documentation Contributing Guide](https://www.authelia.com/contributing/prologue/documentation/) for more
+See the [Documentation Contributing Guide](https://www.authelia.com/contributing/prologue/documentation-contributions/) for more
 information.

--- a/content/en/contributing/prologue/documentation.md
+++ b/content/en/contributing/prologue/documentation.md
@@ -42,7 +42,7 @@ The following steps will allow you to run the website on the localhost and view 
   ```bash
   git clone https://github.com/authelia/authelia.git
   cd authelia/docs
-  npm run install
+  npm install
   npm run start
   ```
 


### PR DESCRIPTION
docs: fix instructions on testing doc changes
The instructions say to run  the `install` script, however there is no `install` script in `package.json`. Developers should instead run `npm install`

docs: fix broken link to contributing documentation
The README link to the contributing documentation is broken. Update it to the correct link.

